### PR TITLE
Key bindings for Vanilla Atlas Buttons

### DIFF
--- a/src/main/java/antiqueatlasautomarker/AntiqueAtlasAutoMarker.java
+++ b/src/main/java/antiqueatlasautomarker/AntiqueAtlasAutoMarker.java
@@ -1,5 +1,6 @@
 package antiqueatlasautomarker;
 
+import antiqueatlasautomarker.client.KeyHandler;
 import antiqueatlasautomarker.command.PutMarkerCommand;
 import antiqueatlasautomarker.config.AutoMarkSetting;
 import antiqueatlasautomarker.config.ConfigHandler;
@@ -63,8 +64,12 @@ public class AntiqueAtlasAutoMarker {
 
     @Mod.EventHandler
     public void init(FMLInitializationEvent event){
-        if(ConfigHandler.enchantments.enableLibrarianKey && event.getSide().equals(Side.CLIENT))
-            LibrarianMarkerHandler.initKeybind();
+        if(event.getSide().equals(Side.CLIENT)) {
+            if(ConfigHandler.enchantments.enableLibrarianKey)
+                LibrarianMarkerHandler.initKeybind();
+            if(ConfigHandler.overhaul.basicKeybindings)
+                KeyHandler.initKeybind();
+        }
     }
 
     @Mod.EventHandler

--- a/src/main/java/antiqueatlasautomarker/client/KeyHandler.java
+++ b/src/main/java/antiqueatlasautomarker/client/KeyHandler.java
@@ -1,0 +1,33 @@
+package antiqueatlasautomarker.client;
+
+import net.minecraft.client.settings.KeyBinding;
+import net.minecraftforge.fml.client.registry.ClientRegistry;
+import org.lwjgl.input.Keyboard;
+
+public class KeyHandler {
+
+    public static KeyBinding addButtonKey;
+    public static KeyBinding deleteButtonKey;
+    public static KeyBinding toggleButtonKey;
+
+    public static void initKeybind() {
+        addButtonKey = new KeyBinding(
+                "gui.antiqueatlas.addMarker",
+                Keyboard.KEY_A,
+                "key.antiqueatlas.category"
+        );
+        deleteButtonKey = new KeyBinding(
+                "gui.antiqueatlas.delMarker",
+                Keyboard.KEY_D,
+                "key.antiqueatlas.category"
+        );
+        toggleButtonKey = new KeyBinding(
+                "gui.antiqueatlas.hideMarkers",
+                Keyboard.KEY_W,
+                "key.antiqueatlas.category"
+        );
+        ClientRegistry.registerKeyBinding(addButtonKey);
+        ClientRegistry.registerKeyBinding(deleteButtonKey);
+        ClientRegistry.registerKeyBinding(toggleButtonKey);
+    }
+}

--- a/src/main/java/antiqueatlasautomarker/config/folders/AAOverhaulConfig.java
+++ b/src/main/java/antiqueatlasautomarker/config/folders/AAOverhaulConfig.java
@@ -66,4 +66,11 @@ public class AAOverhaulConfig {
     @MixinConfig.MixinToggle(lateMixin = "mixins.aaam.antiqueatlas.selectmarkersvertically.json", defaultValue = true)
     @MixinConfig.CompatHandling(modid = "antiqueatlas", desired = true)
     public boolean verticalScrolling = true;
+
+    @Config.Comment("Enable setting keybindings for the Add, Delete, and Hide/Show Marker buttons. This also removes the mouse position reset behavior of the delete marker button.")
+    @Config.Name("Keybindings for Buttons")
+    @Config.RequiresMcRestart
+    @MixinConfig.MixinToggle(lateMixin = "mixins.aaam.antiqueatlas.atlasbasickeybinds.json", defaultValue = true)
+    @MixinConfig.CompatHandling(modid = "antiqueatlas", desired = true)
+    public boolean basicKeybindings = true;
 }

--- a/src/main/java/antiqueatlasautomarker/mixin/antiqueatlas/keybindsforbuttons/ButtonKeybindAtlasMixin.java
+++ b/src/main/java/antiqueatlasautomarker/mixin/antiqueatlas/keybindsforbuttons/ButtonKeybindAtlasMixin.java
@@ -1,0 +1,65 @@
+package antiqueatlasautomarker.mixin.antiqueatlas.keybindsforbuttons;
+
+import antiqueatlasautomarker.client.KeyHandler;
+import com.llamalad7.mixinextras.sugar.Local;
+import hunternif.mc.atlas.client.gui.GuiAtlas;
+import hunternif.mc.atlas.client.gui.GuiBookmarkButton;
+import hunternif.mc.atlas.client.gui.core.GuiComponent;
+import hunternif.mc.atlas.client.gui.core.GuiCursor;
+import hunternif.mc.atlas.client.gui.core.GuiStates;
+import org.spongepowered.asm.mixin.Final;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Mutable;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(GuiAtlas.class)
+public abstract class ButtonKeybindAtlasMixin extends GuiComponent {
+
+    @Shadow(remap = false) @Final private GuiBookmarkButton btnMarker;
+    @Shadow(remap = false) @Final private GuiBookmarkButton btnDelMarker;
+    @Shadow(remap = false) @Final private GuiBookmarkButton btnShowMarkers;
+    @Shadow(remap = false) @Final private GuiCursor eraser;
+
+    @Shadow (remap = false) @Mutable
+    @Final private GuiStates.IState DELETING_MARKER;
+
+    @Inject(
+            method = "<init>",
+            at = @At("TAIL"),
+            remap = false
+    )
+    public void aaam_cancelDeleteResettingPosition(CallbackInfo ci){
+        // I don't know why it originally needed to grab the mouse cursor, but the behavior is awkward
+        DELETING_MARKER = new GuiStates.IState() {
+            @Override
+            public void onEnterState() {
+                addChild(eraser);
+                btnDelMarker.setSelected(true);
+            }
+            @Override
+            public void onExitState() {
+                removeChild(eraser);
+                btnDelMarker.setSelected(false);
+            }
+        };
+    }
+
+    @Inject(
+            method = "handleKeyboardInput",
+            at = @At(value = "INVOKE", target = "Lnet/minecraft/client/settings/KeyBinding;getKeyCode()I", ordinal = 0)
+    )
+    public void aaam_keybindClicksButton(CallbackInfo ci, @Local int key) {
+        if(KeyHandler.addButtonKey.isActiveAndMatches(key)){
+            ((GuiComponentButtonInvoker)this.btnMarker).invokeOnClick();
+        }
+        else if(KeyHandler.deleteButtonKey.isActiveAndMatches(key)){
+            ((GuiComponentButtonInvoker)this.btnDelMarker).invokeOnClick();
+        }
+        else if(KeyHandler.toggleButtonKey.isActiveAndMatches(key)){
+            ((GuiComponentButtonInvoker)this.btnShowMarkers).invokeOnClick();
+        }
+    }
+}

--- a/src/main/java/antiqueatlasautomarker/mixin/antiqueatlas/keybindsforbuttons/GuiComponentButtonInvoker.java
+++ b/src/main/java/antiqueatlasautomarker/mixin/antiqueatlas/keybindsforbuttons/GuiComponentButtonInvoker.java
@@ -1,0 +1,10 @@
+package antiqueatlasautomarker.mixin.antiqueatlas.keybindsforbuttons;
+
+import hunternif.mc.atlas.client.gui.core.GuiComponentButton;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.gen.Invoker;
+
+@Mixin(GuiComponentButton.class)
+public interface GuiComponentButtonInvoker {
+    @Invoker(value = "onClick", remap = false) void invokeOnClick();
+}

--- a/src/main/resources/mixins.aaam.antiqueatlas.atlasbasickeybinds.json
+++ b/src/main/resources/mixins.aaam.antiqueatlas.atlasbasickeybinds.json
@@ -1,0 +1,18 @@
+{
+  "required": true,
+  "package": "antiqueatlasautomarker.mixin.antiqueatlas.keybindsforbuttons",
+  "refmap": "mixins.antiqueatlasautomarker.refmap.json",
+  "compatibilityLevel": "JAVA_8",
+  "target": "@env(DEFAULT)",
+  "minVersion": "0.8",
+  "mixins": [
+
+  ],
+  "injectors": {
+    "maxShiftBy": 10
+  },
+  "client": [
+    "ButtonKeybindAtlasMixin",
+    "GuiComponentButtonInvoker"
+  ]
+}


### PR DESCRIPTION
Key bindings that call the onClick behavior of the Atlas buttons for Add, Delete, and Show/Hide Marker. Will perform normal and Shift key click behaviors.

Key binding lang keys use existing Antique Atlas ones.

Also removed the mouse cursor being reset to the middle of the screen when using the Delete Marker behavior.

https://github.com/user-attachments/assets/40329967-de28-46fb-9dda-c11680843f86

